### PR TITLE
webcam image loader

### DIFF
--- a/octoprint_octodashcompanion/static/html/webcam.html
+++ b/octoprint_octodashcompanion/static/html/webcam.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <title>Webcam</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+        }
+        .imgbox {
+            display: grid;
+            width: 100vw;
+            height: 100vh;
+        }
+        .center-fit {
+            max-width: 100%;
+            max-height: auto;
+            margin: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="imgbox">
+        <img class="center-fit" src="/webcam/?action=stream">
+    </div>
+</body>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_octodashcompanion"
 plugin_name = "OctoDash Companion"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.0.2dev1"
+plugin_version = "0.0.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Add static web page that can be embedded in Custom Action button using the command `[!WEB]http://localhost/plugin/octodashcompanion/static/html/webcam.html` to display the webcam stream in an iframe. Assumes functioning webcam URL at `/webcam/?action=stream`. Will be looking into making this dynamically loaded from OctoPrint's settings. 